### PR TITLE
feat(azure-devops): support repository module contract

### DIFF
--- a/azure_devops/terraform-azuredevops-repositorios/.gitignore
+++ b/azure_devops/terraform-azuredevops-repositorios/.gitignore
@@ -5,6 +5,7 @@
 *.backup
 .terraform/
 .terraform*
+.terragrunt-cache/
 .terraform.lock.hcl
 
 # VSCode

--- a/azure_devops/terraform-azuredevops-repositorios/CHANGELOG.md
+++ b/azure_devops/terraform-azuredevops-repositorios/CHANGELOG.md
@@ -1,25 +1,32 @@
 # Changelog
 
-Todas as mudanças importantes deste projeto serão documentadas neste arquivo.
+Todas as mudancas importantes deste projeto serao documentadas neste arquivo.
 
-O formato segue o padrão [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), 
-e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR/).
+O formato segue o padrao [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+e este projeto adere ao [Versionamento Semantico](https://semver.org/lang/pt-BR/).
 
 ## [Unreleased]
+
 ### Adicionado
-- Configuração inicial de módulos Terraform para criação de recursos no AWS S3.
-- Template básico para definição e reutilização de módulos Terraform.
-- Configuração inicial para uso com Terragrunt.
+
+- Suporte documentado para renomear repositorios mantendo uma chave logica estavel no mapa `repositories`.
+- Configuracao inicial de modulos Terraform para criacao de recursos no AWS S3.
+- Template basico para definicao e reutilizacao de modulos Terraform.
+- Configuracao inicial para uso com Terragrunt.
 
 ### Corrigido
-- Correção de erros de digitação na documentação inicial.
+
+- Correcao de erros de digitacao na documentacao inicial.
 - Ajustes nos exemplos para refletir a sintaxe atualizada do Terraform.
 
 ### Removido
-- Dependência obsoleta do Terraform 0.12, migrando para versões mais recentes.
+
+- Dependencia obsoleta do Terraform 0.12, migrando para versoes mais recentes.
 
 ## [1.0.0] - 2024-11-24
+
 ### Adicionado
-- Módulo inicial do Terraform para gerenciamento de repositórios no Azure DevOps.
-- Suporte à criação automatizada de repositórios com configuração da branch padrão.
-- Documentação inicial do projeto para facilitar a configuração e o uso.
+
+- Modulo inicial do Terraform para gerenciamento de repositorios no Azure DevOps.
+- Suporte a criacao automatizada de repositorios com configuracao da branch padrao.
+- Documentacao inicial do projeto para facilitar a configuracao e o uso.

--- a/azure_devops/terraform-azuredevops-repositorios/README.md
+++ b/azure_devops/terraform-azuredevops-repositorios/README.md
@@ -1,68 +1,78 @@
-<!-- BEGIN_TF_DOCS -->
-### Repositório Módulos Terraform
+# terraform-azuredevops-repositorios
 
-Bem-vindo à documentação deste repositório de módulos Terraform. O objetivo deste projeto é criar módulos para uso pessoal, mas também torná-los disponíveis para que outros colaboradores da comunidade possam utilizá-los e contribuir para o seu aprimoramento.
+Modulo Terraform para criar e renomear repositorios no Azure DevOps.
 
-<p>
-  <img src="https://img.shields.io/badge/License-MIT-green.svg" alt="MIT License" />
-</p>
+## Acoes suportadas
 
-![EdevOps-Logo](https://i.imgur.com/LVpNbS0.png)
+- Criar repositorios em um projeto Azure DevOps existente.
+- Alterar o nome de repositorios ja gerenciados pelo Terraform.
+- Definir a branch padrao por repositorio.
+- Expor as URLs dos repositorios gerenciados.
 
-## Requirements
+## Como renomear repositorios com seguranca
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0, < 2.0 |
-| <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) | 1.4.0 |
+O modulo usa `for_each` sobre o mapa `repositories`. A chave do mapa e o endereco
+estavel do recurso no state. Para renomear, preserve a chave e altere apenas
+`name`.
 
-## Providers
+```hcl
+repositories = {
+  gcp = {
+    name           = "cloud-gcp-infra"
+    default_branch = "main"
+  }
+}
+```
 
-| Name | Version |
-|------|---------|
-| <a name="provider_azuredevops"></a> [azuredevops](#provider\_azuredevops) | 1.4.0 |
+Evite trocar a chave `gcp`, porque isso faria o Terraform entender como outro
+recurso.
 
-## Modules
+## Uso com Terragrunt
 
-No modules.
+```hcl
+terraform {
+  source = get_env(
+    "TG_AZURE_DEVOPS_REPOSITORIES_MODULE_SOURCE",
+    "git::https://github.com/Edwanderson94/Terraform-Modules.git//azure_devops/terraform-azuredevops-repositorios?ref=develop"
+  )
+}
 
-## Resources
+inputs = {
+  project_name          = "Infrastructure"
+  org_service_url       = get_env("AZDO_ORG_SERVICE_URL", "https://dev.azure.com/Tecnoform")
+  personal_access_token = get_env("AZDO_PERSONAL_ACCESS_TOKEN")
 
-| Name | Type |
-|------|------|
-| [azuredevops_git_repository.repositories](https://registry.terraform.io/providers/microsoft/azuredevops/1.4.0/docs/resources/git_repository) | resource |
-| [azuredevops_project.project_infra](https://registry.terraform.io/providers/microsoft/azuredevops/1.4.0/docs/data-sources/project) | data source |
+  repositories = {
+    aws = {
+      name           = "cloud-aws-infra"
+      default_branch = "main"
+    }
+  }
+}
+```
+
+Em pipelines produtivos, prefira usar uma tag ou commit imutavel no `source`, ou
+aponte `TG_AZURE_DEVOPS_REPOSITORIES_MODULE_SOURCE` para um checkout controlado
+do repo `Terraform-Modules`.
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_org_service_url"></a> [org\_service\_url](#input\_org\_service\_url) | URL da sua organization no Azure DevOps | `string` | n/a | yes |
-| <a name="input_personal_access_token"></a> [personal\_access\_token](#input\_personal\_access\_token) | PAT de acesso a sua organization no Azure DevOps | `string` | n/a | yes |
-| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Nome do projeto no Azure DevOps | `any` | n/a | yes |
-| <a name="input_repositories"></a> [repositories](#input\_repositories) | Lista de repositórios a serem criados | <pre>map(object({<br/>    name           = string<br/>    default_branch = string<br/>  }))</pre> | n/a | yes |
+| Nome | Tipo | Descricao |
+| --- | --- | --- |
+| `project_name` | `string` | Nome do projeto Azure DevOps. |
+| `org_service_url` | `string` | URL da organizacao Azure DevOps. |
+| `personal_access_token` | `string` | PAT do Azure DevOps. Valor sensivel. |
+| `repositories` | `map(object)` | Mapa de repositorios com chave logica estavel, nome e branch padrao. |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_module_version"></a> [module\_version](#output\_module\_version) | Versão do módulo |
-| <a name="output_repository_urls"></a> [repository\_urls](#output\_repository\_urls) | Lista de URLs dos repositórios criados |
+| Nome | Descricao |
+| --- | --- |
+| `module_version` | Versao interna do modulo. |
+| `repository_urls` | URLs dos repositorios gerenciados, indexadas pela chave logica. |
 
-### Contribuição
+## Requisitos
 
-Contribuições são muito bem-vindas! Se você deseja colaborar, siga as instruções abaixo:
-
-1. Envie pull requests com suas alterações ou melhorias.
-2. Caso encontre algum erro ou tenha sugestões, crie uma *issue* no repositório.
-
-Agradecemos pela sua colaboração e interesse!
-
-## Autores
-
-- [@Edwanderson94](https://github.com/Edwanderson94)
-
-### Considerações Finais
-
-A maior motivação para a criação desses módulos foi a jornada de aprendizado e experiência que adquiri ao longo da minha trajetória profissional. Meu objetivo é compartilhar esse conhecimento, oferecendo módulos para Azure DevOps utilizando Terraform, com o intuito de proporcionar maior agilidade e eficiência aos projetos de outros profissionais.
-<!-- END_TF_DOCS -->
+- Terraform `>= 1.0, < 2.0`.
+- Provider `microsoft/azuredevops` `1.4.0`.
+- Projeto Azure DevOps ja existente.

--- a/azure_devops/terraform-azuredevops-repositorios/example/README.md
+++ b/azure_devops/terraform-azuredevops-repositorios/example/README.md
@@ -1,89 +1,63 @@
+## Exemplo Terragrunt para Azure Repos
 
-## Terragrunt para Gerenciamento de Segredos na AWS
+Este exemplo mostra como consumir o modulo `terraform-azuredevops-repositorios` para criar e renomear repositorios no Azure DevOps.
 
-Este exemplo apresenta um código **Terragrunt** que utiliza um módulo **Terraform** para criar e gerencia o recurso **Azure Repos**.
-
-<p>
-  <img src="https://img.shields.io/badge/License-MIT-green.svg" alt="MIT License" />
-</p>
-
-![EdevOps-Logo](https://i.imgur.com/LVpNbS0.png)
-
-
-### Pré-requisito
-
-Para executar este código, é necessário que o Terragrunt esteja configurado no sistema operacional. O Terragrunt é uma ferramenta que estende o Terraform, facilitando o uso de módulos e a gestão de configurações em múltiplos ambientes.
-
-
-### Utilização e Exemplo
-
-O código utiliza o Terragrunt para encapsular e gerenciar a chamada ao módulo Terraform.
+O ponto principal e manter a chave do mapa `repositories` estavel. Para renomear um repositorio ja gerenciado, altere apenas o campo `name` e preserve a chave logica, como `aws`, `oci`, `azure` ou `gcp`.
 
 ```hcl
-
-# Inclui o arquivo terragrunt.hcl do diretório raiz
+# Inclui o arquivo terragrunt.hcl do diretorio raiz
 include {
   path = find_in_parent_folders()
 }
 
 terraform {
-  source = "git::https://github.com/Edwanderson94/Terraform-Modules.git//terraform-azdo-modules/azuredevops_repository?ref=<versao-modulo>>"
+  source = get_env(
+    "TG_AZURE_DEVOPS_REPOSITORIES_MODULE_SOURCE",
+    "git::https://github.com/Edwanderson94/Terraform-Modules.git//azure_devops/terraform-azuredevops-repositorios?ref=develop"
+  )
 }
 
-inputs = {
-  project_name          = "nome-do-seu-projeto"
-  org_service_url       = "https://dev.azure.com/nome-do-seu-projeto"
-  personal_access_token = "seu-token-pat-do-azure-devops"
+locals {
+  repository_names = {
+    aws   = "cloud-aws-infra"
+    oci   = "cloud-oci-infra"
+    azure = "cloud-azure-infra"
+    gcp   = "cloud-gcp-infra"
+  }
+
+  repository_default_branches = {
+    aws   = "main"
+    oci   = "develop"
+    azure = "uat"
+    gcp   = "main"
+  }
 
   repositories = {
-    "repo-01" = {
-      name           = "repo-01"
-      default_branch = "main"
-    },
-
-    "repo-02" = {
-      name           = "repo-02"
-      default_branch = "dev"
-    },
-
-    "repo-03" = {
-      name           = "repo-03"
-      default_branch = "uat"
+    for key, name in local.repository_names : key => {
+      name           = name
+      default_branch = local.repository_default_branches[key]
     }
   }
 }
 
+inputs = {
+  project_name          = "nome-do-seu-projeto"
+  org_service_url       = get_env("AZDO_ORG_SERVICE_URL", "https://dev.azure.com/nome-da-sua-organizacao")
+  personal_access_token = get_env("AZDO_PERSONAL_ACCESS_TOKEN")
+  repositories          = local.repositories
+}
 ```
 
-### Stack utilizada
+### Acoes suportadas
 
-- Infraestrutura como Código (IaC): Terraform, Terragrunt
-- Cloud Provider: Azure
-- Serviço: Azure DevOps
-- Recurso: Azure Repos
-- Repositório do Módulo: GitHub 
+- Criar repositorios no Azure DevOps.
+- Alterar o nome de repositorios gerenciados mantendo a mesma chave logica no mapa `repositories`.
+- Definir a branch padrao por repositorio.
 
-### Referências
- - [Gruntwork.oi - Terragrunt](https://terragrunt.gruntwork.io/docs/)
- - [HashCorp - Terraform Azure DevOps](https://registry.terraform.io/providers/microsoft/azuredevops/latest)
+### Variaveis esperadas em pipeline
 
-### Contribuindo
+- `AZDO_ORG_SERVICE_URL`: URL da organizacao Azure DevOps.
+- `AZDO_PERSONAL_ACCESS_TOKEN`: PAT usado pelo provider Azure DevOps.
+- `TG_AZURE_DEVOPS_REPOSITORIES_MODULE_SOURCE`: source opcional do modulo. Use para apontar para checkout local do repo `Terraform-Modules` em pipelines multi-repo.
 
-Contribuições são sempre bem-vindas! Se você deseja colaborar, siga os seguintes passos:
-
-1. Envie pull requests com suas alterações ou melhorias.
-2. Caso encontre algum erro ou tenha sugestões, crie uma *issue* no repositório.
-
-Agradecemos pela sua colaboração e interesse!
-
-
-### Autores
-
-- [@Edwanderson94](https://github.com/Edwanderson94)
-
-
-### Considerações Finais
-
-Neste projeto, aprofundei meus conhecimentos em Terraform e Terragrunt, aplicando-os ao gerenciamento de recursos no Azure Repos. Durante o desenvolvimento, trabalhei com conceitos importantes, como a configuração de branches, permitindo definir automaticamente a branch padrão logo após a criação de um repositório no Azure DevOps.
-
-Essa abordagem simplifica o gerenciamento de repositórios e contribui para uma configuração mais eficiente e padronizada.
+Em pipelines produtivos, prefira apontar o source para uma tag ou commit imutavel do repo `Terraform-Modules`.

--- a/azure_devops/terraform-azuredevops-repositorios/example/terragrunt.hcl
+++ b/azure_devops/terraform-azuredevops-repositorios/example/terragrunt.hcl
@@ -1,31 +1,41 @@
-# Inclui o arquivo terragrunt.hcl do diretório raiz
+# Inclui o arquivo terragrunt.hcl do diretorio raiz
 include {
   path = find_in_parent_folders()
 }
 
 terraform {
-  source = "git::https://github.com/Edwanderson94/Terraform-Modules.git//terraform-azdo-modules/azuredevops_repository?ref=<versao-modulo>>"
+  source = get_env(
+    "TG_AZURE_DEVOPS_REPOSITORIES_MODULE_SOURCE",
+    "git::https://github.com/Edwanderson94/Terraform-Modules.git//azure_devops/terraform-azuredevops-repositorios?ref=develop"
+  )
+}
+
+locals {
+  repository_names = {
+    aws   = "cloud-aws-infra"
+    oci   = "cloud-oci-infra"
+    azure = "cloud-azure-infra"
+    gcp   = "cloud-gcp-infra"
+  }
+
+  repository_default_branches = {
+    aws   = "main"
+    oci   = "develop"
+    azure = "uat"
+    gcp   = "main"
+  }
+
+  repositories = {
+    for key, name in local.repository_names : key => {
+      name           = name
+      default_branch = local.repository_default_branches[key]
+    }
+  }
 }
 
 inputs = {
   project_name          = "nome-do-seu-projeto"
-  org_service_url       = "https://dev.azure.com/nome-do-seu-projeto"
-  personal_access_token = "seu-token-pat-do-azure-devops"
-
-  repositories = {
-    "repo-01" = {
-      name           = "repo-01"
-      default_branch = "main"
-    },
-
-    "repo-02" = {
-      name           = "repo-02"
-      default_branch = "dev"
-    },
-
-    "repo-03" = {
-      name           = "repo-03"
-      default_branch = "uat"
-    }
-  }
+  org_service_url       = get_env("AZDO_ORG_SERVICE_URL", "https://dev.azure.com/nome-da-sua-organizacao")
+  personal_access_token = get_env("AZDO_PERSONAL_ACCESS_TOKEN")
+  repositories          = local.repositories
 }

--- a/azure_devops/terraform-azuredevops-repositorios/locals.tf
+++ b/azure_devops/terraform-azuredevops-repositorios/locals.tf
@@ -1,9 +1,7 @@
-# Definindo a versão do módulo
 locals {
-  module_version = "1.0.0"
+  module_version = "1.1.0"
 }
 
-# Criando um mapa de repositórios onde a chave é o nome do repositório
 locals {
   repositories_map = {
     for key, repo in var.repositories :

--- a/azure_devops/terraform-azuredevops-repositorios/main.tf
+++ b/azure_devops/terraform-azuredevops-repositorios/main.tf
@@ -1,8 +1,8 @@
 # ================================================================
 # Owner: Edwanderson
-# Description: Módulo de Criação de Repositórios
-# Project: Módulo de Terraform para Azure DevOps
-# =================================================================
+# Description: Module for creating and renaming Azure DevOps repositories
+# Project: Terraform module for Azure DevOps
+# ================================================================
 
 resource "azuredevops_git_repository" "repositories" {
   for_each = local.repositories_map

--- a/azure_devops/terraform-azuredevops-repositorios/output.tf
+++ b/azure_devops/terraform-azuredevops-repositorios/output.tf
@@ -3,12 +3,12 @@
 # ================================================================
 
 output "module_version" {
-  description = "Versão do módulo"
+  description = "Versao do modulo"
   value       = local.module_version
 }
 
 output "repository_urls" {
-  description = "Lista de URLs dos repositórios criados"
+  description = "Lista de URLs dos repositorios gerenciados"
   value = {
     for key, repo in azuredevops_git_repository.repositories :
     key => repo.web_url

--- a/azure_devops/terraform-azuredevops-repositorios/variables.tf
+++ b/azure_devops/terraform-azuredevops-repositorios/variables.tf
@@ -3,17 +3,12 @@
 # ================================================================
 
 variable "repositories" {
-  description = "Lista de repositórios a serem criados"
+  description = "Mapa de repositorios gerenciados. Use uma chave logica estavel para permitir renomear o repositorio alterando apenas o campo name"
   type = map(object({
     name           = string
     default_branch = string
   }))
 }
-
-# variable "project_id" {
-#   description = "ID do projeto no Azure DevOps"
-#   type        = string
-# }
 
 variable "org_service_url" {
   description = "URL da sua organization no Azure DevOps"
@@ -28,4 +23,5 @@ variable "personal_access_token" {
 
 variable "project_name" {
   description = "Nome do projeto no Azure DevOps"
+  type        = string
 }


### PR DESCRIPTION
## O que mudou

- Estrutura o modulo `terraform-azuredevops-repositorios` para criar e renomear repositorios mantendo chaves logicas estaveis.
- Atualiza exemplos Terragrunt para consumo local ou via `TG_AZURE_DEVOPS_REPOSITORIES_MODULE_SOURCE`.
- Documenta uso em pipeline multi-repo e recomendacao de source imutavel em ambiente produtivo.
- Atualiza versao interna do modulo para `1.1.0` e limpa documentacao/comentarios com encoding antigo.

## Validacao

- `git diff --check`
- `terraform fmt -recursive -check`
- `terraform init -backend=false -input=false`
- `terraform validate -no-color`
- Validado tambem via `terragrunt plan -no-color` no repo live `Terraform`, retornando `No changes`.