### PR TITLE
docs: standardize module readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,201 @@
+# Terraform Modules
 
-## Repositório Módulos Terraform
+Catálogo de módulos Terraform reutilizáveis para provisionar e padronizar
+recursos de infraestrutura.
 
-Bem-vindo à documentação deste repositório de módulos Terraform. O objetivo deste projeto é criar módulos para uso pessoal, mas também torná-los disponíveis para que outros colaboradores da comunidade possam utilizá-los e contribuir para o seu aprimoramento.
+Este repositório foi pensado como um produto: os módulos devem ser genéricos,
+documentados, versionados por tags e consumidos por outros repositórios de live
+stacks.
 
-<p>
-  <img src="https://img.shields.io/badge/License-MIT-green.svg" alt="MIT License" />
-</p>
+```text
+Terraform-Modules = módulos reutilizáveis
+Terraform         = live stacks que consomem os módulos
+```
 
-![EdevOps-Logo](https://i.imgur.com/LVpNbS0.png)
+## Objetivo
 
-### Objetivo
+Centralizar módulos Terraform que possam ser usados em projetos pessoais,
+ambientes corporativos e, futuramente, por outras pessoas da comunidade.
 
-Este repositório tem como propósito centralizar módulos, documentações e exemplos práticos relacionados ao uso do Terraform. Aqui você encontrará:
+Cada módulo deve ter:
 
-- **Módulos reutilizáveis** para provisionamento de recursos.
-- **Estruturas de implementação** aplicadas em plataformas como:
-  - **Azure DevOps**
-  - **AWS**
+- contrato claro de inputs e outputs;
+- exemplo funcional;
+- documentação de uso;
+- versionamento semântico;
+- changelog;
+- validação com `terraform fmt` e `terraform validate`.
 
-Explore, aprenda e contribua para expandir este repositório com ideias e melhorias!
+## Módulos Disponíveis
 
----
+| Plataforma | Módulo | Caminho | Status |
+| --- | --- | --- | --- |
+| Azure DevOps | Repositórios Git | `azure_devops/repos` | Funcional |
+| Azure DevOps | Pipelines | `azure_devops/pipelines` | Em estruturação |
+| AWS | Secrets Manager | `aws/terraform-aws-secretmanager` | Funcional |
 
-### Azure DevOps
+## Como Consumir Um Módulo
 
-O **Azure DevOps** é um conjunto de ferramentas e serviços da Microsoft voltado para o gerenciamento completo do ciclo de vida do desenvolvimento de software, com foco em integração contínua (CI), entrega contínua (CD) e colaboração entre equipes de desenvolvimento. Ele oferece uma plataforma baseada em nuvem usada para planejar, construir, testar e implantar aplicações, automatizando e agilizando os fluxos de trabalho das equipes.
+Use sempre uma tag versionada no `source`.
 
----
+Exemplo:
 
-### Módulos Azure DevOps
+```hcl
+module "azuredevops_repositories" {
+  source = "git::https://github.com/Edwanderson94/Terraform-Modules.git//azure_devops/repos?ref=v1.3.2"
 
-Dentro da pasta **azure_devops**, você encontrará os módulos específicos para o Azure DevOps, com funcionalidades diversas. A seguir, destaco o módulo disponível:
+  org_service_url       = var.org_service_url
+  personal_access_token = var.personal_access_token
+  project_name          = var.project_name
 
-#### 1. **terraform-azuredevops-repositorios**
+  repositories = {
+    aws = {
+      name           = "cloud-aws-infra"
+      default_branch = "master"
+    }
+  }
+}
+```
 
-Este módulo permite a criação de repositórios no Azure DevOps de maneira automatizada. Com ele, é possível realizar várias ações de uma única vez, como:
+Evite consumir diretamente branches mutáveis, como `develop` ou `master`, em
+pipelines produtivas.
 
-- Criar novos repositórios no Azure DevOps.
-- Definir a branch **default** do repositório, ajustando conforme suas necessidades.
+## Estrutura Recomendada de Módulo
 
-Este módulo facilita a configuração e o provisionamento de repositórios em sua organização, garantindo uma gestão eficiente e padronizada.
+Cada módulo deve seguir este padrão:
 
----
+```text
+module-name/
+├── README.md
+├── CHANGELOG.md
+├── versions.tf
+├── main.tf
+├── variables.tf
+├── outputs.tf
+└── examples/
+```
 
-### Módulos AWS 
+Quando o provider precisar de dados auxiliares, também podem existir arquivos
+como:
 
-Dentro da pasta **aws**, você encontrará os módulos específicos para o Azure DevOps, com funcionalidades diversas. A seguir, destaco o módulo disponível:
+```text
+data.tf
+locals.tf
+```
 
-#### 1. **terraform-aws-secretmanager**
+## Azure DevOps
 
-Este módulo foi desenvolvido para simplificar a criação e o gerenciamento de secrets na AWS de forma automatizada e eficiente. Com ele, você pode realizar diversas ações simultaneamente, como:
+Os módulos Azure DevOps ficam em:
 
-- Criar múltiplos secrets na AWS em uma única execução.
-- Definir o nome de cada secret de forma personalizada.
-- Configurar o número de dias para o recovery window (janela de recuperação).
-- Opcionalmente, atribuir um valor inicial ao secret (atenção: isso pode expor a senha no código; recomenda-se definir a senha posteriormente via console AWS para maior segurança).
+```text
+azure_devops/
+```
 
-Este módulo torna a configuração e o provisionamento de secrets mais rápidos e organizados, auxiliando no gerenciamento seguro de credenciais e informações sensíveis.
+Estrutura desejada:
 
----
+```text
+azure_devops/
+├── README.md
+├── repos/
+├── pipelines/
+├── variable_groups/
+├── service_connections/
+├── environments/
+└── permissions/
+```
 
-### Contribuição
+### `azure_devops/repos`
 
-Contribuições são muito bem-vindas! Se você deseja colaborar, siga as instruções abaixo:
+Módulo para gerenciar Azure Repos.
 
-1. Envie pull requests com suas alterações ou melhorias.
-2. Caso encontre algum erro ou tenha sugestões, crie uma *issue* no repositório.
+Principais capacidades:
 
-Agradecemos pela sua colaboração e interesse!
+- criar repositórios;
+- renomear repositórios mantendo uma chave lógica estável;
+- criar branches padronizadas;
+- renomear branches;
+- remover branches antigas;
+- configurar branch padrão;
+- expor URLs dos repositórios.
 
-### Autores
+Documentação específica:
+
+```text
+azure_devops/repos/README.md
+```
+
+## AWS
+
+Os módulos AWS ficam em:
+
+```text
+aws/
+```
+
+### `aws/terraform-aws-secretmanager`
+
+Módulo para criação e gerenciamento de secrets no AWS Secrets Manager.
+
+Documentação específica:
+
+```text
+aws/terraform-aws-secretmanager/README.md
+```
+
+## Versionamento
+
+Este repositório segue versionamento semântico:
+
+```text
+MAJOR.MINOR.PATCH
+```
+
+Exemplos:
+
+```text
+v1.3.2
+v1.4.0
+v2.0.0
+```
+
+Use:
+
+- `PATCH` para correções compatíveis;
+- `MINOR` para novas funcionalidades compatíveis;
+- `MAJOR` para mudanças incompatíveis.
+
+## Fluxo de Desenvolvimento
+
+Fluxo recomendado:
+
+```text
+feature/* -> develop -> master -> tag
+```
+
+Antes de publicar uma tag:
+
+```bash
+terraform fmt -recursive
+terraform validate
+```
+
+Quando possível, valide também os exemplos do módulo.
+
+## Boas Práticas
+
+- Módulos devem ser genéricos e reutilizáveis.
+- Configurações específicas de ambiente não devem ficar no módulo.
+- Segredos não devem ser hardcoded.
+- Inputs sensíveis devem usar `sensitive = true`.
+- Outputs não devem expor segredos.
+- Live stacks devem consumir módulos por tag.
+- Mudanças importantes devem ser documentadas no `CHANGELOG.md`.
+
+## Licença
+
+Este projeto está licenciado sob a licença MIT. Consulte o arquivo
+[`LICENSE`](./LICENSE) para mais detalhes.
+
+## Autor
 
 - [@Edwanderson94](https://github.com/Edwanderson94)
-
----
-
-### Considerações Finais
-
-A maior motivação para a criação desses módulos foi a jornada de aprendizado e experiência que adquiri ao longo da minha trajetória profissional. Meu objetivo é compartilhar esse conhecimento, oferecendo módulos para Azure DevOps utilizando Terraform, com o intuito de proporcionar maior agilidade e eficiência aos projetos de outros profissionais.

--- a/azure_devops/repos/README.md
+++ b/azure_devops/repos/README.md
@@ -1,23 +1,93 @@
-# terraform-azuredevops-repositorios
+# Azure DevOps Repositories
 
-Modulo Terraform para criar e renomear repositorios no Azure DevOps.
+Módulo Terraform para gerenciar Azure Repos em um projeto Azure DevOps existente.
 
-## Acoes suportadas
+Este módulo foi desenhado para ser reutilizável. Configurações específicas de
+ambiente, como nomes dos repositórios da sua organização, devem ficar nas live
+stacks que consomem o módulo.
 
-- Criar repositorios em um projeto Azure DevOps existente.
-- Alterar o nome de repositorios ja gerenciados pelo Terraform.
-- Criar branches declaradas em `repository_branches`.
-- Renomear branches por repositorio com `repository_branch_renames`.
-- Deletar branches por repositorio com `repository_branches_to_delete`.
-- Padronizar as branches `develop`, `homolog` e `master`.
-- Definir `master` como branch padrao por repositorio.
-- Expor as URLs dos repositorios gerenciados.
+## Capacidades
 
-## Como renomear repositorios com seguranca
+- Criar repositórios Git no Azure DevOps.
+- Renomear repositórios mantendo uma chave lógica estável no Terraform state.
+- Criar branches padronizadas.
+- Renomear branches por repositório.
+- Remover branches antigas por repositório.
+- Configurar branch padrão por repositório.
+- Expor URLs dos repositórios gerenciados.
 
-O modulo usa `for_each` sobre o mapa `repositories`. A chave do mapa e o endereco
-estavel do recurso no state. Para renomear, preserve a chave e altere apenas
-`name`.
+## Requisitos
+
+| Requisito | Versão |
+| --- | --- |
+| Terraform | `>= 1.0, < 2.0` |
+| Provider `microsoft/azuredevops` | `1.4.0` |
+| Provider `hashicorp/null` | `~> 3.2` |
+
+O projeto Azure DevOps deve existir antes da execução.
+
+## Uso
+
+Exemplo Terraform:
+
+```hcl
+module "azuredevops_repositories" {
+  source = "git::https://github.com/Edwanderson94/Terraform-Modules.git//azure_devops/repos?ref=v1.3.2"
+
+  org_service_url       = var.org_service_url
+  personal_access_token = var.personal_access_token
+  project_name          = var.project_name
+
+  repositories = {
+    aws = {
+      name           = "cloud-aws-infra"
+      default_branch = "master"
+    }
+
+    terraform_state = {
+      name           = "terraform-state"
+      default_branch = "master"
+    }
+  }
+
+  repository_branches = ["develop", "homolog", "master"]
+}
+```
+
+Exemplo Terragrunt:
+
+```hcl
+terraform {
+  source = "git::https://github.com/Edwanderson94/Terraform-Modules.git//azure_devops/repos?ref=v1.3.2"
+}
+
+inputs = {
+  org_service_url       = get_env("AZDO_ORG_SERVICE_URL")
+  personal_access_token = get_env("AZDO_PERSONAL_ACCESS_TOKEN")
+  project_name          = "Infrastructure"
+
+  repositories = {
+    aws = {
+      name           = "cloud-aws-infra"
+      default_branch = "master"
+    }
+  }
+
+  repository_branches = ["develop", "homolog", "master"]
+}
+```
+
+Use tags versionadas no `source`. Evite consumir `develop` ou `master` em
+pipelines produtivas.
+
+## Como Renomear Repositórios
+
+O módulo usa `for_each` sobre o mapa `repositories`.
+
+A chave do mapa é a identidade do recurso no Terraform state. O campo `name` é
+o nome real do repositório no Azure DevOps.
+
+Para renomear com segurança, mantenha a chave e altere apenas `name`.
 
 ```hcl
 repositories = {
@@ -28,71 +98,89 @@ repositories = {
 }
 ```
 
-Evite trocar a chave `gcp`, porque isso faria o Terraform entender como outro
-recurso.
-
-## Uso com Terragrunt
+Para renomear:
 
 ```hcl
-terraform {
-  source = get_env(
-    "TG_AZURE_DEVOPS_REPOSITORIES_MODULE_SOURCE",
-    "git::https://github.com/Edwanderson94/Terraform-Modules.git//azure_devops/repos?ref=develop"
-  )
-}
-
-inputs = {
-  project_name          = "Infrastructure"
-  org_service_url       = get_env("AZDO_ORG_SERVICE_URL", "https://dev.azure.com/Tecnoform")
-  personal_access_token = get_env("AZDO_PERSONAL_ACCESS_TOKEN")
-
-  repositories = {
-    aws = {
-      name           = "cloud-aws-infra"
-      default_branch = "master"
-    }
-  }
-
-  repository_branches = ["develop", "homolog", "master"]
-
-  repository_branch_renames = {
-    aws = {
-      main = "master"
-    }
-  }
-
-  repository_branches_to_delete = {
-    azure = ["uat"]
+repositories = {
+  gcp = {
+    name           = "cloud-google-infra"
+    default_branch = "master"
   }
 }
 ```
 
-Em pipelines produtivos, prefira usar uma tag ou commit imutavel no `source`, ou
-aponte `TG_AZURE_DEVOPS_REPOSITORIES_MODULE_SOURCE` para um checkout controlado
-do repo `Terraform-Modules`.
+Não altere a chave `gcp` sem necessidade. Trocar a chave faz o Terraform
+entender que é outro recurso.
+
+## Como Gerenciar Branches
+
+Branches que devem existir em todos os repositórios:
+
+```hcl
+repository_branches = ["develop", "homolog", "master"]
+```
+
+Renomear branches por repositório:
+
+```hcl
+repository_branch_renames = {
+  aws = {
+    main = "master"
+  }
+}
+```
+
+Remover branches antigas:
+
+```hcl
+repository_branches_to_delete = {
+  aws   = ["main"]
+  azure = ["uat"]
+}
+```
+
+O módulo impede a remoção de branches protegidas pela configuração desejada,
+como a branch padrão e as branches listadas em `repository_branches`.
 
 ## Inputs
 
-| Nome | Tipo | Descricao |
-| --- | --- | --- |
-| `project_name` | `string` | Nome do projeto Azure DevOps. |
-| `org_service_url` | `string` | URL da organizacao Azure DevOps. |
-| `personal_access_token` | `string` | PAT do Azure DevOps. Valor sensivel. |
-| `repositories` | `map(object)` | Mapa de repositorios com chave logica estavel, nome e branch padrao. |
-| `repository_branches` | `list(string)` | Branches que devem existir em todos os repositorios. |
-| `repository_branch_renames` | `map(map(string))` | Branches a renomear por repositorio. |
-| `repository_branches_to_delete` | `map(list(string))` | Branches a deletar por repositorio. |
+| Nome | Tipo | Obrigatório | Descrição |
+| --- | --- | --- | --- |
+| `org_service_url` | `string` | Sim | URL da organização Azure DevOps. |
+| `personal_access_token` | `string` | Sim | PAT usado pelo provider Azure DevOps. Valor sensível. |
+| `project_name` | `string` | Sim | Nome do projeto Azure DevOps existente. |
+| `repositories` | `map(object({ name = string, default_branch = string }))` | Sim | Repositórios gerenciados, indexados por chave lógica estável. |
+| `repository_branches` | `list(string)` | Não | Branches que devem existir em todos os repositórios. Padrão: `["develop", "homolog", "master"]`. |
+| `repository_branch_renames` | `map(map(string))` | Não | Mapa de renome de branches por repositório. |
+| `repository_branches_to_delete` | `map(list(string))` | Não | Branches antigas que devem ser removidas por repositório. |
 
 ## Outputs
 
-| Nome | Descricao |
+| Nome | Descrição |
 | --- | --- |
-| `module_version` | Versao interna do modulo. |
-| `repository_branches` | Branches padronizadas nos repositorios gerenciados. |
-| `repository_urls` | URLs dos repositorios gerenciados, indexadas pela chave logica. |
+| `module_version` | Versão interna do módulo. |
+| `repository_branches` | Branches padronizadas nos repositórios gerenciados. |
+| `repository_urls` | URLs dos repositórios gerenciados, indexadas pela chave lógica. |
 
-## Requisitos
+## Validação Local
 
-- Terraform `>= 1.0, < 2.0`.
-- Provider `microsoft/azuredevops` `1.4.0`.
-- Projeto Azure DevOps ja existente.
+```bash
+terraform fmt -check
+terraform init
+terraform validate
+```
+
+Para validar o exemplo Terragrunt:
+
+```bash
+cd example
+terragrunt hcl format --check
+```
+
+## Observações
+
+- O módulo usa chamadas auxiliares à API do Azure DevOps para padronizar
+  branches.
+- O PAT precisa ter permissão para administrar repositórios no projeto alvo.
+- Evite hardcode de segredos em live stacks.
+- Em pipelines, injete `AZDO_PERSONAL_ACCESS_TOKEN` como secret variable.


### PR DESCRIPTION
﻿## O que mudou

- Corrige e padroniza o README raiz do catálogo `Terraform-Modules`.
- Padroniza o README do módulo `azure_devops/repos`.
- Documenta consumo via tag versionada, estrutura recomendada de módulos, versionamento semântico e validação local.
- Explica o contrato do módulo de Azure Repos: criação, renome de repositórios, branches, inputs e outputs.

## Validação

- `terraform fmt -check azure_devops\repos`
- Verificação de mojibake nos READMEs alterados
